### PR TITLE
Include unistd.h for gcc 4.7

### DIFF
--- a/commands.cpp
+++ b/commands.cpp
@@ -22,6 +22,7 @@
 #include "util.hpp"
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <unistd.h>
 #include <stdint.h>
 #include <algorithm>
 #include <string>


### PR DESCRIPTION
In gcc 4.7, some includes were removed.
The build fails for me on gcc (Ubuntu/Linaro 4.7.2-2ubuntu1) 4.7.2.

This fixes the build.
