### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CXX := c++
-CXXFLAGS := -Wall -pedantic -ansi -Wno-long-long -O2
+CXXFLAGS := -Wall -pedantic -Wno-long-long -O2
 LDFLAGS := -lcrypto
 PREFIX := /usr/local
 


### PR DESCRIPTION
Installed latest Cygwin and couldn't run make without removing -ansi flag. 
https://github.com/AGWA/git-crypt/blob/master/Makefile#L2

make -version 4
gcc -v 4.9.0-1
Else I got this problem:
https://cygwin.com/ml/cygwin/2014-01/msg00130.html
