### PR TITLE
Create leading directories when installing.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,6 @@ clean:
 	rm -f *.o git-crypt
 
 install: git-crypt
-	install -m 755 git-crypt $(DESTDIR)$(PREFIX)/bin/
+	install -Dm 755 git-crypt $(DESTDIR)$(PREFIX)/bin/
 
 .PHONY: all clean install


### PR DESCRIPTION
When installing to a custom DESTDIR or PREFIX (rather common for downstream packaging), it's not ususual for the installation directory to be inexistant.

This PR creates it when copying over the binary. This is also rather common practice.