### PR TITLE
read gpg program from git config gpg.program 

### DIFF
--- a/commands.cpp
+++ b/commands.cpp
@@ -254,7 +254,7 @@ static std::string get_internal_key_path (const char* key_name)
 	return path;
 }
 
-static std::string get_git_config (const std::string& name)
+std::string get_git_config (const std::string& name)
 {
 	// git config --get
 	std::vector<std::string>	command;

--- a/commands.hpp
+++ b/commands.hpp
@@ -70,4 +70,7 @@ void help_migrate_key (std::ostream&);
 void help_refresh (std::ostream&);
 void help_status (std::ostream&);
 
+// other
+std::string get_git_config (const std::string& name);
+
 #endif

--- a/gpg.cpp
+++ b/gpg.cpp
@@ -35,9 +35,10 @@
 
 static std::string gpg_get_executable()
 {
-    std::string gpgbin = get_git_config("gpg.program");
-    if (gpgbin == "") {
-        gpgbin = "gpg";
+    std::string gpgbin = "gpg";
+    try {
+        gpgbin = get_git_config("gpg.program");
+    } catch (...) {
     }
     return gpgbin;
 }

--- a/gpg.cpp
+++ b/gpg.cpp
@@ -30,8 +30,17 @@
 
 #include "gpg.hpp"
 #include "util.hpp"
+#include "commands.hpp"
 #include <sstream>
 
+static std::string gpg_get_executable()
+{
+    std::string gpgbin = get_git_config("gpg.program");
+    if (gpgbin == "") {
+        gpgbin = "gpg";
+    }
+    return gpgbin;
+}
 static std::string gpg_nth_column (const std::string& line, unsigned int col)
 {
 	std::string::size_type	pos = 0;
@@ -62,7 +71,7 @@ std::string gpg_get_uid (const std::string& fingerprint)
 {
 	// gpg --batch --with-colons --fixed-list-mode --list-keys 0x7A399B2DB06D039020CD1CE1D0F3702D61489532
 	std::vector<std::string>	command;
-	command.push_back("gpg");
+	command.push_back(gpg_get_executable());
 	command.push_back("--batch");
 	command.push_back("--with-colons");
 	command.push_back("--fixed-list-mode");
@@ -94,7 +103,7 @@ std::vector<std::string> gpg_lookup_key (const std::string& query)
 
 	// gpg --batch --with-colons --fingerprint --list-keys jsmith@example.com
 	std::vector<std::string>	command;
-	command.push_back("gpg");
+	command.push_back(gpg_get_executable());
 	command.push_back("--batch");
 	command.push_back("--with-colons");
 	command.push_back("--fingerprint");
@@ -125,7 +134,7 @@ std::vector<std::string> gpg_list_secret_keys ()
 {
 	// gpg --batch --with-colons --list-secret-keys --fingerprint
 	std::vector<std::string>	command;
-	command.push_back("gpg");
+	command.push_back(gpg_get_executable());
 	command.push_back("--batch");
 	command.push_back("--with-colons");
 	command.push_back("--list-secret-keys");
@@ -154,7 +163,7 @@ void gpg_encrypt_to_file (const std::string& filename, const std::string& recipi
 {
 	// gpg --batch -o FILENAME -r RECIPIENT -e
 	std::vector<std::string>	command;
-	command.push_back("gpg");
+	command.push_back(gpg_get_executable());
 	command.push_back("--batch");
 	if (key_is_trusted) {
 		command.push_back("--trust-model");
@@ -174,7 +183,7 @@ void gpg_decrypt_from_file (const std::string& filename, std::ostream& output)
 {
 	// gpg -q -d FILENAME
 	std::vector<std::string>	command;
-	command.push_back("gpg");
+	command.push_back(gpg_get_executable());
 	command.push_back("-q");
 	command.push_back("-d");
 	command.push_back(filename);


### PR DESCRIPTION
User alanrossmachinery added an unmerged patch to read the gpg program from the git-config variable "gpg.program". This patch just re-bases that patch on master, and uses the `get_git_config` function to pull the correct key, defaulting to "gpg" if none is found.
This is the git-config key used by other programs.
