### PR TITLE
WIP: build git-crypt with an alpine wrapper

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM alpine:edge
+MAINTAINER John Torres <enfermo337@yahoo.com>
+
+WORKDIR /workspace
+
+RUN apk add --no-cache libgcc libstdc++ libcrypto1.0 libssl1.0 openssl-dev gcc g++ make git && \
+    git clone https://github.com/AGWA/git-crypt /workspace && \
+    make && \
+    make install PREFIX=/usr/local && \
+    apk del openssl-dev gcc g++ make git && \
+    rm -rf /workspace


### PR DESCRIPTION
Simple dockerfile that builds git-crypt for alpine linux and wraps it in a small container ~9MB.

This could stand to be improved so that it pulls the current code revision (and or is pushed into the container build context from the current checkout.

Probably a quick fix to add a make target that pushes the code context and version info.