### PR TITLE
Fix for -Wdeprecated-declarations warnings on GCC 7.2.0

### DIFF
--- a/crypto-openssl.cpp
+++ b/crypto-openssl.cpp
@@ -59,8 +59,8 @@ Aes_ecb_encryptor::Aes_ecb_encryptor (const unsigned char* raw_key)
 
 Aes_ecb_encryptor::~Aes_ecb_encryptor ()
 {
-	// Note: Explicit destructor necessary because class contains an auto_ptr
-	// which contains an incomplete type when the auto_ptr is declared.
+	// Note: Explicit destructor necessary because class contains an unique_ptr
+	// which contains an incomplete type when the unique_ptr is declared.
 
 	explicit_memset(&impl->key, '\0', sizeof(impl->key));
 }
@@ -82,8 +82,8 @@ Hmac_sha1_state::Hmac_sha1_state (const unsigned char* key, size_t key_len)
 
 Hmac_sha1_state::~Hmac_sha1_state ()
 {
-	// Note: Explicit destructor necessary because class contains an auto_ptr
-	// which contains an incomplete type when the auto_ptr is declared.
+	// Note: Explicit destructor necessary because class contains an unique_ptr
+	// which contains an incomplete type when the unique_ptr is declared.
 
 	HMAC_cleanup(&(impl->ctx));
 }

--- a/crypto.hpp
+++ b/crypto.hpp
@@ -57,7 +57,7 @@ public:
 private:
 	struct Aes_impl;
 
-	std::auto_ptr<Aes_impl>	impl;
+	std::unique_ptr<Aes_impl>	impl;
 
 public:
 	Aes_ecb_encryptor (const unsigned char* key);
@@ -102,7 +102,7 @@ public:
 private:
 	struct Hmac_impl;
 
-	std::auto_ptr<Hmac_impl>	impl;
+	std::unique_ptr<Hmac_impl>	impl;
 
 public:
 	Hmac_sha1_state (const unsigned char* key, size_t key_len);

--- a/util-unix.cpp
+++ b/util-unix.cpp
@@ -193,8 +193,10 @@ std::vector<std::string> get_directory_contents (const char* path)
 		errno = 0;
 
 		while((ent = readdir(dir)) != NULL && errno == 0) {
-			if (std::strcmp(ent->d_name, ".") && std::strcmp(ent->d_name, ".."))
-				contents.push_back(ent->d_name);
+			if (std::strcmp(ent->d_name, ".") == 0 || std::strcmp(ent->d_name, "..") == 0) {
+				continue;
+			}
+			contents.push_back(ent->d_name);
 		}
 
 		if(errno)

--- a/util-unix.cpp
+++ b/util-unix.cpp
@@ -179,19 +179,6 @@ int util_rename (const char* from, const char* to)
 	return rename(from, to);
 }
 
-static size_t sizeof_dirent_for (DIR* p)
-{
-	long name_max = fpathconf(dirfd(p), _PC_NAME_MAX);
-	if (name_max == -1) {
-		#ifdef NAME_MAX
-		name_max = NAME_MAX;
-		#else
-		name_max = 255;
-		#endif
-	}
-	return offsetof(struct dirent, d_name) + name_max + 1; // final +1 is for d_name's null terminator
-}
-
 std::vector<std::string> get_directory_contents (const char* path)
 {
 	std::vector<std::string>		contents;
@@ -201,19 +188,18 @@ std::vector<std::string> get_directory_contents (const char* path)
 		throw System_error("opendir", path, errno);
 	}
 	try {
-		std::vector<unsigned char>	buffer(sizeof_dirent_for(dir));
-		struct dirent*			dirent_buffer = reinterpret_cast<struct dirent*>(&buffer[0]);
 		struct dirent*			ent = NULL;
-		int				err = 0;
-		while ((err = readdir_r(dir, dirent_buffer, &ent)) == 0 && ent != NULL) {
-			if (std::strcmp(ent->d_name, ".") == 0 || std::strcmp(ent->d_name, "..") == 0) {
-				continue;
-			}
-			contents.push_back(ent->d_name);
+
+		errno = 0;
+
+		while((ent = readdir(dir)) != NULL && errno == 0) {
+			if (std::strcmp(ent->d_name, ".") && std::strcmp(ent->d_name, ".."))
+				contents.push_back(ent->d_name);
 		}
-		if (err != 0) {
-			throw System_error("readdir_r", path, errno);
-		}
+
+		if(errno)
+			throw System_error("readdir", path, errno);
+
 	} catch (...) {
 		closedir(dir);
 		throw;


### PR DESCRIPTION
When compiling this, I noticed there are some compilation warnings for the use of std::auto_ptr and readdir_r(). I changed it to use std::unique_ptr instead and readdir. The function readdir is now reentrant.