### PR TITLE
Update URL for docbook.xsl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ BINDIR ?= $(PREFIX)/bin
 MANDIR ?= $(PREFIX)/share/man
 
 ENABLE_MAN ?= no
-DOCBOOK_XSL ?= http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl
+DOCBOOK_XSL ?= http://cdn.docbook.org/release/xsl-nons/current/manpages/docbook.xsl
 
 OBJFILES = \
     git-crypt.o \


### PR DESCRIPTION
Per https://lists.oasis-open.org/archives/docbook-apps/201612/msg00011.html Docbook XSL stylesheets are no longer hosted at sourceforge.