### PR TITLE
Patched git_checkout command to work with large repos on Mac

### DIFF
--- a/commands.cpp
+++ b/commands.cpp
@@ -187,16 +187,15 @@ static bool git_checkout (const std::vector<std::string>& paths)
 {
 	std::vector<std::string>	command;
 
-	command.push_back("git");
-	command.push_back("checkout");
-	command.push_back("--");
-
 	for (std::vector<std::string>::const_iterator path(paths.begin()); path != paths.end(); ++path) {
+		command.push_back("git");
+		command.push_back("checkout");
+		command.push_back("--");
 		command.push_back(*path);
-	}
-
-	if (!successful_exit(exec_command(command))) {
-		return false;
+		if (!successful_exit(exec_command(command))) {
+			return false;
+		}
+		command.clear();
 	}
 
 	return true;


### PR DESCRIPTION
Patched git_checkout function to iterate trough the files instead of doing all in one go. OSX has a hardcoded max arguments size that is much smaller than on Linux and after having issues decrypting a larger repo, this made it work in the end.

Perhaps not the optimal solution, but it worked for us. 