### PR TITLE
Compatibility with OpenSSL 1.1.0 `no-deprecated'

### DIFF
--- a/crypto-openssl-11.cpp
+++ b/crypto-openssl-11.cpp
@@ -46,7 +46,7 @@
 
 void init_crypto ()
 {
-	ERR_load_crypto_strings();
+	OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS, nullptr);
 }
 
 struct Aes_ecb_encryptor::Aes_impl {


### PR DESCRIPTION
OpenSSL 1.1.0 deprecates a lot of APIs, and may be built with those deprecated APIs disabled entirely.

This PR replaces deprecated APIs with their replacements in `crypto-openssl-11.cpp`.