### PR TITLE
Add git-crypt merge driver to support secret files merging (refactored #107)

### DIFF
--- a/README
+++ b/README
@@ -28,8 +28,8 @@ Configure a repository to use git-crypt:
 
 Specify files to encrypt by creating a .gitattributes file:
 
-	secretfile filter=git-crypt diff=git-crypt
-	*.key filter=git-crypt diff=git-crypt
+	secretfile filter=git-crypt diff=git-crypt merge=git-crypt
+	*.key filter=git-crypt diff=git-crypt merge=git-crypt
 
 Like a .gitignore file, it can match wildcards and should be checked into
 the repository.  See below for more information about .gitattributes.
@@ -151,8 +151,8 @@ Also note that the pattern `dir/*` does not match files under
 sub-directories of dir/.  To encrypt an entire sub-tree dir/, place the
 following in dir/.gitattributes:
 
-	* filter=git-crypt diff=git-crypt
-	.gitattributes !filter !diff
+	* filter=git-crypt diff=git-crypt merge=git-crypt
+	.gitattributes !filter !diff !merge
 
 The second pattern is essential for ensuring that .gitattributes itself
 is not encrypted.

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ Configure a repository to use git-crypt:
 
 Specify files to encrypt by creating a .gitattributes file:
 
-    secretfile filter=git-crypt diff=git-crypt
-    *.key filter=git-crypt diff=git-crypt
+    secretfile filter=git-crypt diff=git-crypt merge=git-crypt
+    *.key filter=git-crypt diff=git-crypt merge=git-crypt
 
 Like a .gitignore file, it can match wildcards and should be checked into
 the repository.  See below for more information about .gitattributes.
@@ -153,8 +153,8 @@ Also note that the pattern `dir/*` does not match files under
 sub-directories of dir/.  To encrypt an entire sub-tree dir/, place the
 following in dir/.gitattributes:
 
-    * filter=git-crypt diff=git-crypt
-    .gitattributes !filter !diff
+    * filter=git-crypt diff=git-crypt merge=git-crypt
+    .gitattributes !filter !diff !merge
 
 The second pattern is essential for ensuring that .gitattributes itself
 is not encrypted.

--- a/commands.hpp
+++ b/commands.hpp
@@ -45,6 +45,7 @@ struct Error {
 int clean (int argc, const char** argv, std::istream& in = std::cin, std::ostream& out = std::cout);
 int smudge (int argc, const char** argv, std::istream& in = std::cin, std::ostream& out = std::cout);
 int diff (int argc, const char** argv);
+int merge (int argc, const char** argv);
 // Public commands:
 int init (int argc, const char** argv);
 int unlock (int argc, const char** argv);

--- a/commands.hpp
+++ b/commands.hpp
@@ -33,6 +33,7 @@
 
 #include <string>
 #include <iosfwd>
+#include <iostream>
 
 struct Error {
 	std::string	message;
@@ -41,8 +42,8 @@ struct Error {
 };
 
 // Plumbing commands:
-int clean (int argc, const char** argv);
-int smudge (int argc, const char** argv);
+int clean (int argc, const char** argv, std::istream& in = std::cin, std::ostream& out = std::cout);
+int smudge (int argc, const char** argv, std::istream& in = std::cin, std::ostream& out = std::cout);
 int diff (int argc, const char** argv);
 // Public commands:
 int init (int argc, const char** argv);

--- a/doc/multiple_keys.md
+++ b/doc/multiple_keys.md
@@ -11,7 +11,7 @@ option to `git-crypt init` as follows:
 To encrypt a file with an alternative key, use the `git-crypt-KEYNAME`
 filter in `.gitattributes` as follows:
 
-    secretfile filter=git-crypt-KEYNAME diff=git-crypt-KEYNAME
+    secretfile filter=git-crypt-KEYNAME diff=git-crypt-KEYNAME merge=git-crypt-KEYNAME
 
 To export an alternative key or share it with a GPG user, pass the `-k
 KEYNAME` option to `git-crypt export-key` or `git-crypt add-gpg-user`

--- a/git-crypt.cpp
+++ b/git-crypt.cpp
@@ -73,6 +73,7 @@ static void print_usage (std::ostream& out)
 	out << "   clean [LEGACY-KEYFILE]" << std::endl;
 	out << "   smudge [LEGACY-KEYFILE]" << std::endl;
 	out << "   diff [LEGACY-KEYFILE] FILE" << std::endl;
+	out << "   merge" << std::endl;
 	*/
 	out << std::endl;
 	out << "See 'git-crypt help COMMAND' for more information on a specific command." << std::endl;
@@ -230,6 +231,9 @@ try {
 		}
 		if (std::strcmp(command, "diff") == 0) {
 			return diff(argc, argv);
+		}
+		if (std::strcmp(command, "merge") == 0) {
+			return merge(argc, argv);
 		}
 	} catch (const Option_error& e) {
 		std::clog << "git-crypt: Error: " << e.option_name << ": " << e.message << std::endl;

--- a/man/git-crypt.xml
+++ b/man/git-crypt.xml
@@ -310,11 +310,11 @@
 		<para>
 			Then, you specify the files to encrypt by creating a
 			<citerefentry><refentrytitle>gitattributes</refentrytitle><manvolnum>5</manvolnum></citerefentry> file.
-			Each file which you want to encrypt should be assigned the "<literal>filter=git-crypt diff=git-crypt</literal>"
+			Each file which you want to encrypt should be assigned the "<literal>filter=git-crypt diff=git-crypt merge=git-crypt</literal>"
 			attributes.  For example:
 		</para>
 
-		<screen>secretfile filter=git-crypt diff=git-crypt&#10;*.key filter=git-crypt diff=git-crypt</screen>
+		<screen>secretfile filter=git-crypt diff=git-crypt merge=git-crypt&#10;*.key filter=git-crypt diff=git-crypt merge=git-crypt</screen>
 
 		<para>
 			Like a <filename>.gitignore</filename> file, <filename>.gitattributes</filename> files can match wildcards and
@@ -383,7 +383,7 @@
 			following in <filename>dir/.gitattributes</filename>:
 		</para>
 
-		<screen>* filter=git-crypt diff=git-crypt&#10;.gitattributes !filter !diff</screen>
+		<screen>* filter=git-crypt diff=git-crypt merge=git-crypt&#10;.gitattributes !filter !diff !merge</screen>
 
 		<para>
 			The second pattern is essential for ensuring that <filename>.gitattributes</filename> itself
@@ -414,7 +414,7 @@
 			filter in <filename>.gitattributes</filename> as follows:
 		</para>
 
-		<screen><replaceable>secretfile</replaceable> filter=git-crypt-<replaceable>KEYNAME</replaceable> diff=git-crypt-<replaceable>KEYNAME</replaceable></screen>
+		<screen><replaceable>secretfile</replaceable> filter=git-crypt-<replaceable>KEYNAME</replaceable> diff=git-crypt-<replaceable>KEYNAME</replaceable> merge=git-crypt-<replaceable>KEYNAME</replaceable></screen>
 
 		<para>
 			To export an alternative key or share it with a GPG user, pass the


### PR DESCRIPTION
This PR is a refactoring of PR #107. The original PR mixes multiple unrelated changes in a single commit, including some maybe unwanted changes and code-style violations, which is probably the reason why it’s still not merged.

This PR contains only and only the changes needed for the merge driver support with minimum changes to the existing code (separated into an extra commit), so it should be easy for review. I’ve also fixed a few shortcomings in the original PR.