### PR TITLE
Add add-gpg-user --trusted documentation to the READMEs

### DIFF
--- a/README
+++ b/README
@@ -42,6 +42,10 @@ Share the repository with others (or with yourself) using GPG:
 
 	$ git-crypt add-gpg-user USER_ID
 
+If its a collaborator key you might need to trust the key:
+
+	$ git-crypt add-gpg-user --trusted USER_ID
+
 USER_ID can be a key ID, a full fingerprint, an email address, or anything
 else that uniquely identifies a public key to GPG (see "HOW TO SPECIFY
 A USER ID" in the gpg man page).  Note: `git-crypt add-gpg-user` will

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ Share the repository with others (or with yourself) using GPG:
 
     git-crypt add-gpg-user USER_ID
 
+If its a collaborator key you might need to trust the key:
+
+    git-crypt add-gpg-user --trusted USER_ID
+
 `USER_ID` can be a key ID, a full fingerprint, an email address, or
 anything else that uniquely identifies a public key to GPG (see "HOW TO
 SPECIFY A USER ID" in the gpg man page).  Note: `git-crypt add-gpg-user`


### PR DESCRIPTION
Hi completely forgot that we need to trust the key when adding a collaborator to the repository having error like:

```
gpg: XXX: There is no assurance this key belongs to the named user
gpg: [stdin]: encryption failed: Unusable public key
git-crypt: GPG error: Failed to encrypt
```

ref https://github.com/AGWA/git-crypt/issues/23

Cheers,
Laurent