### PR TITLE
Don't encrypt empty files in new repositories

### DIFF
--- a/commands.cpp
+++ b/commands.cpp
@@ -770,6 +770,10 @@ int clean (int argc, const char** argv)
 		return 1;
 	}
 
+	if (file_size == 0 && key_file.get_skip_empty()) {
+		return 0;
+	}
+
 	// We use an HMAC of the file as the encryption nonce (IV) for CTR mode.
 	// By using a hash of the file we ensure that the encryption is
 	// deterministic so git doesn't think the file has changed when it really
@@ -887,6 +891,11 @@ int smudge (int argc, const char** argv)
 	// Read the header to get the nonce and make sure it's actually encrypted
 	unsigned char		header[10 + Aes_ctr_decryptor::NONCE_LEN];
 	std::cin.read(reinterpret_cast<char*>(header), sizeof(header));
+
+	if (std::cin.gcount() == 0 && key_file.get_skip_empty()) {
+		return 0;
+	}
+
 	if (std::cin.gcount() != sizeof(header) || std::memcmp(header, "\0GITCRYPT\0", 10) != 0) {
 		// File not encrypted - just copy it out to stdout
 		std::clog << "git-crypt: Warning: file not encrypted" << std::endl;
@@ -991,6 +1000,7 @@ int init (int argc, const char** argv)
 	std::clog << "Generating key..." << std::endl;
 	Key_file		key_file;
 	key_file.set_key_name(key_name);
+	key_file.set_skip_empty(true);
 	key_file.generate();
 
 	mkdir_parent(internal_key_path);
@@ -1425,6 +1435,7 @@ int keygen (int argc, const char** argv)
 
 	std::clog << "Generating key..." << std::endl;
 	Key_file		key_file;
+	key_file.set_skip_empty(true);
 	key_file.generate();
 
 	if (std::strcmp(key_file_name, "-") == 0) {

--- a/key.cpp
+++ b/key.cpp
@@ -232,6 +232,11 @@ void		Key_file::load_header (std::istream& in)
 				key_name.clear();
 				throw Malformed();
 			}
+		} else if (field_id == HEADER_FIELD_SKIP_EMPTY) {
+			if (field_len != 0) {
+				throw Malformed();
+			}
+			skip_empty = true;
 		} else if (field_id & 1) { // unknown critical field
 			throw Incompatible();
 		} else {
@@ -255,6 +260,10 @@ void		Key_file::store (std::ostream& out) const
 		write_be32(out, HEADER_FIELD_KEY_NAME);
 		write_be32(out, key_name.size());
 		out.write(key_name.data(), key_name.size());
+	}
+	if (skip_empty) {
+		write_be32(out, HEADER_FIELD_SKIP_EMPTY);
+		write_be32(out, 0);
 	}
 	write_be32(out, HEADER_FIELD_END);
 	for (Map::const_iterator it(entries.begin()); it != entries.end(); ++it) {

--- a/key.hpp
+++ b/key.hpp
@@ -83,18 +83,23 @@ public:
 
 	void				set_key_name (const char* k) { key_name = k ? k : ""; }
 	const char*			get_key_name () const { return key_name.empty() ? 0 : key_name.c_str(); }
+
+	void				set_skip_empty (bool v) { skip_empty = v; }
+	bool				get_skip_empty () const { return skip_empty; }
 private:
 	typedef std::map<uint32_t, Entry, std::greater<uint32_t> > Map;
 	enum { FORMAT_VERSION = 2 };
 
 	Map				entries;
 	std::string			key_name;
+	bool				skip_empty = false;
 
 	void				load_header (std::istream&);
 
 	enum {
 		HEADER_FIELD_END	= 0,
-		HEADER_FIELD_KEY_NAME	= 1
+		HEADER_FIELD_KEY_NAME	= 1,
+		HEADER_FIELD_SKIP_EMPTY	= 3	// If this field is present, empty files are left unencrypted (see issue #53)
 	};
 	enum {
 		KEY_FIELD_END		= 0,


### PR DESCRIPTION
git has several problems with using smudge/clean filters on empty files (see issue #53).  The easiest fix is to just not encrypt empty files. Since it was already obvious from the encrypted file length that a file was empty, skipping empty files does not decrease security.
    
Since skipping empty files is a breaking change to the git-crypt file format, we only do this on new repositories. Specifically, we add a new critical header field to the key file called skip_empty which is set in new keys.  We skip empty files if and only if this field is present.
    
Closes: #53
Closes: #162