### PR TITLE
make encryption/decryption faster with big files

### DIFF
--- a/crypto.cpp
+++ b/crypto.cpp
@@ -51,14 +51,14 @@ void Aes_ctr_encryptor::process (const unsigned char* in, unsigned char* out, si
 	for (size_t i = 0; i < len; ++i) {
 		if (byte_counter % BLOCK_LEN == 0) {
 			// Set last 4 bytes of CTR to the (big-endian) block number (sequentially increasing with each block)
-			store_be32(ctr_value + NONCE_LEN, byte_counter / BLOCK_LEN);
+			store_be32(ctr_value + NONCE_LEN, byte_counter >> 4);
 
 			// Generate a new pad
 			ecb.encrypt(ctr_value, pad);
 		}
 
 		// encrypt one byte
-		out[i] = in[i] ^ pad[byte_counter++ % BLOCK_LEN];
+		out[i] = in[i] ^ pad[byte_counter++ & (BLOCK_LEN -1)];
 
 		if (byte_counter == 0) {
 			throw Crypto_error("Aes_ctr_encryptor::process", "Too much data to encrypt securely");


### PR DESCRIPTION
I notice that encryption/decryption will be slow when doing with big files.

1. use `byte_counter++ & (BLOCK_LEN -1)` will be faster  than byte_counter++ % BLOCK_LEN.
2. use EVP methods will be faster than aes-core:

```
$ openssl speed aes-256-cbc
Doing aes-256 cbc for 3s on 16 size blocks: 20421982 aes-256 cbc's in 2.99s
Doing aes-256 cbc for 3s on 64 size blocks: 5347742 aes-256 cbc's in 3.00s
Doing aes-256 cbc for 3s on 256 size blocks: 1263704 aes-256 cbc's in 2.99s
Doing aes-256 cbc for 3s on 1024 size blocks: 308552 aes-256 cbc's in 2.96s
Doing aes-256 cbc for 3s on 8192 size blocks: 40526 aes-256 cbc's in 2.98s
LibreSSL 2.8.3
built on: date not available
options:bn(64,64) rc4(16x,int) des(idx,cisc,16,int) aes(partial) blowfish(idx)
compiler: information not available
The 'numbers' are in 1000s of bytes per second processed.
type             16 bytes     64 bytes    256 bytes   1024 bytes   8192 bytes
aes-256 cbc     109248.19k   114155.14k   108162.40k   106682.45k   111352.49k
```

```
$ openssl speed -evp aes-256-cbc
Doing aes-256-cbc for 3s on 16 size blocks: 171610892 aes-256-cbc's in 2.99s
Doing aes-256-cbc for 3s on 64 size blocks: 39061952 aes-256-cbc's in 2.94s
Doing aes-256-cbc for 3s on 256 size blocks: 9160896 aes-256-cbc's in 2.93s
Doing aes-256-cbc for 3s on 1024 size blocks: 2470343 aes-256-cbc's in 2.93s
Doing aes-256-cbc for 3s on 8192 size blocks: 349873 aes-256-cbc's in 3.00s
LibreSSL 2.8.3
built on: date not available
options:bn(64,64) rc4(16x,int) des(idx,cisc,16,int) aes(partial) blowfish(idx)
compiler: information not available
The 'numbers' are in 1000s of bytes per second processed.
type             16 bytes     64 bytes    256 bytes   1024 bytes   8192 bytes
aes-256-cbc     917066.85k   850782.25k   799582.06k   862127.79k   956856.91k
```
