### PR TITLE
Move internal state dir to 'common' subdir in git path. (Fixes bug with multiple worktrees)

### DIFF
--- a/commands.cpp
+++ b/commands.cpp
@@ -243,17 +243,17 @@ static std::string get_internal_state_path ()
 	std::vector<std::string>	command;
 	command.push_back("git");
 	command.push_back("rev-parse");
-	command.push_back("--git-dir");
+	command.push_back("--git-path");
+	command.push_back("common/git-crypt");
 
 	std::stringstream		output;
 
 	if (!successful_exit(exec_command(command, output))) {
-		throw Error("'git rev-parse --git-dir' failed - is this a Git repository?");
+		throw Error("'git rev-parse --git-path common/git-crypt' failed - is this a Git repository?");
 	}
 
 	std::string			path;
 	std::getline(output, path);
-	path += "/git-crypt";
 
 	return path;
 }


### PR DESCRIPTION
This allows unlocked repos to work correctly with multiple worktrees.

When doing `git worktree add newtree2` in an "unlocked" repo, I get the following output and creating the new worktree fails.

```
Preparing worktree (new branch 'newtree2')
git-crypt: Error: Unable to open key file - have you unlocked/initialized this repository yet?
error: external filter '"/usr/bin/git-crypt" smudge' failed 1
error: external filter '"/usr/bin/git-crypt" smudge' failed
fatal: env/docker-all.secret-env: smudge filter git-crypt failed
```

By putting `strace` in front of the smudge command in `.git/config`, I see:

```
openat(AT_FDCWD, "/home/morgan/Development/dev1/.git/worktrees/newtree2/git-crypt/keys/default", O_RDONLY) = -1 ENOENT (No such file or directory)
```

Git is calling the smudge command when checking out the new working tree, which then fails to find the key file because `git rev-parse` uses a separate dir for each worktree. Hence the `worktrees/newtree2` in the path. The command fails because there is no `git-crypt` dir in `.git/worktrees/newtree2`.

`git rev-parse --git-path` should be used instead of `git rev-parse --git-dir`, based on https://git-scm.com/docs/git-worktree#_details :

> See gitrepository-layout[5] for more information. The rule of thumb is do not make any assumption about whether a path belongs to $GIT_DIR or $GIT_COMMON_DIR when you need to directly access something inside $GIT_DIR. Use git rev-parse --git-path to get the final path.

More importantly, `git-crypt` should be using the `common` subdir of the git dir to store in-use keys, since those need to be shared across workdirs. https://git-scm.com/docs/gitrepository-layout#Documentation/gitrepository-layout.txt-common
