### PR TITLE
Add github workflow to build Windows (64bit) binary

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+### Description of your changes
+<!--
+Briefly describe what this pull request does.
+-->
+
+
+### How has this code been tested?
+<!--
+Before reviewers can be confident in the correctness of this pull request, it
+needs to tested and shown to be correct. Briefly describe the testing that has
+already been done or which is planned for this change.
+-->
+
+### Tasks to do
+- [ ] Read contributing guidelines [contributiing guidlines].
+
+[contributiing guidlines]: ../CONTRIBUTING.md

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,31 @@
+name: build win64
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: windows-2022
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          install: git mingw-w64-x86_64-cc
+
+      - name: building win64
+        run: |
+          pacman -Sy --noconfirm make mingw-w64-x86_64-gcc mingw-w64-x86_64-openssl
+          make -j$(nproc)
+          strip git-crypt.exe
+
+      - name: archive win64 build
+        uses: actions/upload-artifact@v2
+        with:
+          name: git-crypt-win64
+          path: |
+            git-crypt.exe
+          retention-days: 60

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
+.idea/
+
 *.o
+*.exe
 git-crypt

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 #
 
 CXXFLAGS ?= -Wall -pedantic -Wno-long-long -O2
-CXXFLAGS += -std=c++11
+CXXFLAGS += -std=gnu++11
 PREFIX ?= /usr/local
 BINDIR ?= $(PREFIX)/bin
 MANDIR ?= $(PREFIX)/share/man
@@ -25,6 +25,12 @@ OBJFILES = \
     fhstream.o
 
 OBJFILES += crypto-openssl-10.o crypto-openssl-11.o
+
+ifeq ($(OS),Windows_NT)
+	CXXFLAGS += -static -static-libgcc
+	LDFLAGS += -static-libstdc++ -static -lcrypto.dll
+endif
+
 LDFLAGS += -lcrypto
 
 XSLTPROC ?= xsltproc


### PR DESCRIPTION
### Description of your changes
To make `git-crypt` easier to use on Windows I added a workflow which builds the Win64 binary via MSYS in the CI. To do so I:

- added a workflow
- modified the `Makefile` a little (pertty much what @LykkeCity did in https://github.com/LykkeCity/git-crypt)

### How has this code been tested?
- ran the downloaded artifact on Windows 10 successfully

### Tasks to do
- [x] Read contributing guidelines [contributiing guidlines].

[contributiing guidlines]: ../CONTRIBUTING.md

**EDIT:**
Close PR in favour of https://github.com/AGWA/git-crypt/pull/227