### PR TITLE
fix build with libressl >= 3.5.0

### DIFF
--- a/crypto-openssl-10.cpp
+++ b/crypto-openssl-10.cpp
@@ -28,16 +28,15 @@
  * as that of the covered work.
  */
 
-#include <openssl/opensslconf.h>
+#include <openssl/hmac.h>
 
-#if !defined(OPENSSL_API_COMPAT)
+#if defined(HMAC_cleanup)
 
 #include "crypto.hpp"
 #include "key.hpp"
 #include "util.hpp"
 #include <openssl/aes.h>
 #include <openssl/sha.h>
-#include <openssl/hmac.h>
 #include <openssl/evp.h>
 #include <openssl/rand.h>
 #include <openssl/err.h>

--- a/crypto-openssl-11.cpp
+++ b/crypto-openssl-11.cpp
@@ -28,16 +28,15 @@
  * as that of the covered work.
  */
 
-#include <openssl/opensslconf.h>
+#include <openssl/hmac.h>
 
-#if defined(OPENSSL_API_COMPAT)
+#if !defined(HMAC_cleanup)
 
 #include "crypto.hpp"
 #include "key.hpp"
 #include "util.hpp"
 #include <openssl/aes.h>
 #include <openssl/sha.h>
-#include <openssl/hmac.h>
 #include <openssl/evp.h>
 #include <openssl/rand.h>
 #include <openssl/err.h>


### PR DESCRIPTION
Fix the following build failure with libressl >= 3.5.0:

```
crypto-openssl-10.cpp:78:18: error: field 'ctx' has incomplete type 'HMAC_CTX' {aka 'hmac_ctx_st'}
   78 |         HMAC_CTX ctx;
      |                  ^~~
```

Fixes:
 - http://autobuild.buildroot.org/results/98747d470c2ad59280934e160d24bd3fdad1503c

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>