### PR TITLE
make git-crypt add-gpg-user -k default fool-proof

### DIFF
--- a/commands.cpp
+++ b/commands.cpp
@@ -677,10 +677,12 @@ static bool decrypt_repo_keys (std::vector<Key_file>& key_files, uint32_t key_ve
 
 static void encrypt_repo_key (const char* key_name, const Key_file::Entry& key, const std::vector<std::pair<std::string, bool> >& collab_keys, const std::string& keys_path, std::vector<std::string>* new_files)
 {
+	if (!key_name)
+		key_name = "default";
 	std::string	key_file_data;
 	{
 		Key_file this_version_key_file;
-		this_version_key_file.set_key_name(key_name);
+		this_version_key_file.set_key_name(std::strcmp(key_name, "default") != 0 ? key_name : nullptr);
 		this_version_key_file.add(key);
 		key_file_data = this_version_key_file.store_to_string();
 	}
@@ -689,7 +691,7 @@ static void encrypt_repo_key (const char* key_name, const Key_file::Entry& key, 
 		const std::string&	fingerprint(collab->first);
 		const bool		key_is_trusted(collab->second);
 		std::ostringstream	path_builder;
-		path_builder << keys_path << '/' << (key_name ? key_name : "default") << '/' << key.version << '/' << fingerprint << ".gpg";
+		path_builder << keys_path << '/' << key_name << '/' << key.version << '/' << fingerprint << ".gpg";
 		std::string		path(path_builder.str());
 
 		if (access(path.c_str(), F_OK) == 0) {


### PR DESCRIPTION
Unlike most other keys, the default key is encoded using the name `default` in the file system, but inside the key name is empty. If one actually stores the key name `default` inside, the key is rejected by `validate_key_name`.

If one does `git-crypt add-gpg-user` without `-k`, the default key is being used leaving the key name empty and things work. If one specifies `-k default` however, it actually stores the invalid key name `default`. The resulting key file is always rejected by `validate_key_name`.

This commit changes the behaviour of `-k default` to behave as if no `-k` were given.

It is not entirely clear to me whether this change would have prevented #230.