### PR TITLE
[CI/CD] Bump reusable actions in build workflow

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -10,7 +10,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install dependencies
         run: sudo apt install libssl-dev
       - name: Build binary
@@ -32,13 +32,13 @@ jobs:
         with:
           name: git-crypt-artifacts
       - name: Upload release asset
-        uses: actions/github-script@v3
+        uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require("fs").promises;
             const { repo: { owner, repo }, sha } = context;
-            await github.repos.uploadReleaseAsset({
+            await github.rest.repos.uploadReleaseAsset({
               owner, repo,
               release_id: ${{ github.event.release.id }},
               name: 'git-crypt-${{ github.event.release.name }}-linux-x86_64',

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -10,7 +10,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup msys2
         uses: msys2/setup-msys2@v2
         with:
@@ -42,13 +42,13 @@ jobs:
         with:
           name: git-crypt-artifacts
       - name: Upload release asset
-        uses: actions/github-script@v3
+        uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require("fs").promises;
             const { repo: { owner, repo }, sha } = context;
-            await github.repos.uploadReleaseAsset({
+            await github.rest.repos.uploadReleaseAsset({
               owner, repo,
               release_id: ${{ github.event.release.id }},
               name: 'git-crypt-${{ github.event.release.name }}-x86_64.exe',


### PR DESCRIPTION
This PR bumps some outdated reusable actions in build workflows to `actions/checkout@v3` and `actions/github-script@v6`, to solve the warnings of deprecations.

However currently the windows build workflow will fail, since the [openssl packages in MSYS2](https://packages.msys2.org/search?t=pkg&q=openssl) (in this case [`mingw-w64-openssl`](https://packages.msys2.org/base/mingw-w64-openssl)) and [`openssl-devel`](https://packages.msys2.org/package/openssl-devel?repo=msys&variant=x86_64) have been updated to 3.x. This can be fixed by applying the patch in #249.
