### PR TITLE
Enable gpgsm support

### DIFF
--- a/gpg.cpp
+++ b/gpg.cpp
@@ -69,7 +69,9 @@ std::string gpg_get_uid (const std::string& fingerprint)
 	command.push_back(gpg_get_executable());
 	command.push_back("--batch");
 	command.push_back("--with-colons");
-	command.push_back("--fixed-list-mode");
+	if (gpg_get_executable() != "gpgsm") {
+		command.push_back("--fixed-list-mode");
+	}
 	command.push_back("--list-keys");
 	command.push_back("0x" + fingerprint);
 	std::stringstream		command_output;
@@ -111,6 +113,8 @@ std::vector<std::string> gpg_lookup_key (const std::string& query)
 			std::string		line;
 			std::getline(command_output, line);
 			if (line.substr(0, 4) == "pub:") {
+				is_pubkey = true;
+			} else if (line.substr(0, 4) == "crt:") {
 				is_pubkey = true;
 			} else if (line.substr(0, 4) == "sub:") {
 				is_pubkey = false;


### PR DESCRIPTION
This change removes the --fixed-list-mode option if gpg_get_executable is gpgsm since gpgsm does not have that option and the default output of --with-colons is the same as --fixed-list-mode in gnupg 2.

Changes are all in gpg.cpp

In gpg_get_uid we wrap command.push_back("--fixed-list-mode") in an if that checks if gpg_get_executable() is not equal to "gpgsm".

In gpg_lookup_key we add an if else that will set is_pubkey to true if line starts with 'crt:' since x509 certs use crt in place of pub.

These changes enable git-crypt to do gpg encryption with x509 certificates by way of the gpgsm binary in gnupg 2. This is accomplished by setting `git config gpg.program gpgsm`.

This will fix issue #302