### PR TITLE
gpgsm support

### DIFF
--- a/gpg.cpp
+++ b/gpg.cpp
@@ -69,7 +69,9 @@ std::string gpg_get_uid (const std::string& fingerprint)
 	command.push_back(gpg_get_executable());
 	command.push_back("--batch");
 	command.push_back("--with-colons");
-	command.push_back("--fixed-list-mode");
+	if (gpg_get_executable() != "gpgsm") {
+		command.push_back("--fixed-list-mode");
+	}
 	command.push_back("--list-keys");
 	command.push_back("0x" + fingerprint);
 	std::stringstream		command_output;
@@ -111,6 +113,8 @@ std::vector<std::string> gpg_lookup_key (const std::string& query)
 			std::string		line;
 			std::getline(command_output, line);
 			if (line.substr(0, 4) == "pub:") {
+				is_pubkey = true;
+			} else if (line.substr(0, 4) == "crt:") {
 				is_pubkey = true;
 			} else if (line.substr(0, 4) == "sub:") {
 				is_pubkey = false;


### PR DESCRIPTION
gpgsm is a component of gpg2 that allows gpg style operations using x509 certificates.

It lacks the --fixed-list-mode option but that is the default output for --with-colons.

It uses certificates instead of public keys and those certificates are prefixed with crt: instead of pub:.

In gpg_get_uid we wrap the --fixed-list-mode option push in an if so it doesn't get added if gpg_get_executable() is gpgsm.

In gpg_lookup_key we add an if else to set is_pubkey to true for crt lines.

These changes enable git-crypt to make use of gpgsm for users that need to use x509 encryption.

resolves #306 