### PR TITLE
Fix git-crypt in linked worktrees (shared key via --git-common-dir)

### DIFF
--- a/commands.cpp
+++ b/commands.cpp
@@ -239,16 +239,23 @@ static void validate_key_name_or_throw (const char* key_name)
 
 static std::string get_internal_state_path ()
 {
-	// git rev-parse --git-dir
+	// The git-crypt state directory (which holds the symmetric keys) lives in
+	// the shared git directory so that it is reachable from every linked
+	// worktree.  We therefore resolve it via --git-common-dir rather than
+	// --git-dir: in the main worktree the two are identical, but in a linked
+	// worktree --git-dir points at the per-worktree directory
+	// (.git/worktrees/<name>), which never contains the keys.  Using
+	// --git-dir there caused `git worktree add` to fail in the smudge filter
+	// with "Unable to open key file".
 	std::vector<std::string>	command;
 	command.push_back("git");
 	command.push_back("rev-parse");
-	command.push_back("--git-dir");
+	command.push_back("--git-common-dir");
 
 	std::stringstream		output;
 
 	if (!successful_exit(exec_command(command, output))) {
-		throw Error("'git rev-parse --git-dir' failed - is this a Git repository?");
+		throw Error("'git rev-parse --git-common-dir' failed - is this a Git repository?");
 	}
 
 	std::string			path;


### PR DESCRIPTION
Running `git worktree add` inside a git-crypt repository fails in the smudge filter:
```
git-crypt: Error: Unable to open key file - have you unlocked/initialized this repository yet?
error: external filter '"git-crypt" smudge' failed
fatal: <file>: smudge filter git-crypt failed
```

git-crypt resolves its internal state directory (`.git/git-crypt`, which holds the symmetric keys) from `git rev-parse --git-dir`. In a linked worktree that returns `.git/worktrees/<name>`, which never contains the keys — they only ever live in the shared common dir. So checkout of an encrypted file in the new worktree aborts.

---

This PR resolves the state directory via `git rev-parse --git-common-dir` instead.
In the main worktree this is identical to `--git-dir`, so behaviour there is unchanged.
In a linked worktree it points at the shared git directory where the keys live, so checkout, lock and unlock all work transparently.

---

> This is the minimal, shared-key approach. See companion #333 for a variant that preserves per-worktree lock state via a fallback. They touch the same function and are mutually exclusive — pick whichever fits.

Fixes #105